### PR TITLE
adding 1 unified and non-intrusive CM interface to Victima

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,42 @@ Pull this repository via CM:
 cm pull repo CMU-SAFARI@Victima
 ```
 
+#### Run Victima via CM interface
+
+The core CM script for Victima will be available under ```/CM/repos/CMU-SAFARI@Victima/script/reproduce-micro-2023-paper-victima```
+
+It is described by `_cm.yaml` and several native scripts.
+
+Perform the following steps to evaluate Victima with MLCommons CM automation language:
+
+1) This command will install system dependencies for Docker and require sudo (skip it if you have Docker installed):
+```bash
+cmr "reproduce micro 2023 victima _install_deps"
+```
+
+2) This command will prepare and run all experiments via Docker:
+
+```bash
+cmr "reproduce micro 2023 victima _run" 
+```
+
+You can specify --job_manager and --container if needed:
+```bash
+cmr "reproduce micro 2023 victima _run" --job_manager=native|slurm --contianer=docker|podman
+```
+
+3) In case of successful execution of a previous command, this command will generate plots to help you validate results from the article:
+
+```bash
+cmr "reproduce micro 2023 victima _plot"
+```
+
+
+
+#### Alternative way to run Victima via CM sub-scripts
+
+
+
 The CM scripts for Victima will be available under ```/CM/repos/CMU-SAFARI@Victima/script/```
 
 ```

--- a/script/reproduce-micro-2023-paper-victima/README-extra.md
+++ b/script/reproduce-micro-2023-paper-victima/README-extra.md
@@ -1,0 +1,44 @@
+# CM script to run and reproduce experiments
+
+We added support to evaluate Victima using the [MLCommons CM automation language](https://github.com/mlcommons/ck).
+
+Make sure you have install CM. Follow this [guide](https://github.com/mlcommons/ck/blob/master/docs/installation.md) to install it.
+
+Next install reusable MLCommons automations: 
+
+```bash
+cm pull repo mlcommons@ck
+```
+
+Pull this repository via CM:
+```bash
+cm pull repo CMU-SAFARI@Victima
+```
+
+The core CM script for Victima will be available under ```/CM/repos/CMU-SAFARI@Victima/script/reproduce-micro-2023-paper-victima```
+
+It is described by `_cm.yaml` and several native scripts.
+
+Perform the following steps to evaluate Victima with MLCommons CM automation language:
+
+1) This command will install system dependencies for Docker and require sudo (skip it if you have Docker installed):
+```bash
+cmr "reproduce micro 2023 victima _install_deps"
+```
+
+2) This command will prepare and run all experiments via Docker:
+
+```bash
+cmr "reproduce micro 2023 victima _run" 
+```
+
+You can specify --job_manager and --container if needed:
+```bash
+cmr "reproduce micro 2023 victima _run" --job_manager=native|slurm --contianer=docker|podman
+```
+
+3) In case of successful execution of a previous command, this command will generate plots to help you validate results from the article:
+
+```bash
+cmr "reproduce micro 2023 victima _plot"
+```

--- a/script/reproduce-micro-2023-paper-victima/_cm.yaml
+++ b/script/reproduce-micro-2023-paper-victima/_cm.yaml
@@ -1,0 +1,38 @@
+alias: reproduce-micro-2023-paper-victima
+automation_alias: script
+automation_uid: 5b4e0237da074764
+cache: false
+default_env:
+  CM_VICTIMA_JOB_MANAGER: native
+  CM_VICTIMA_CONTAINER: docker
+deps:
+- tags: detect,os
+- names:
+  - python
+  - python3
+  tags: get,python
+- tags: get,git,repo,_repo.https://github.com/CMU-SAFARI/Victima
+  env:
+    CM_GIT_ENV_KEY: 'CMU_SAFARI_VICTIMA'
+  extra_cache_tags: micro23,artifact,ae,cmu,safari,victima
+input_mapping:
+  job_manager: CM_VICTIMA_JOB_MANAGER
+  container: CM_VICTIMA_CONTAINER
+script_name: run
+tags:
+- reproduce
+- paper
+- micro
+- '2023'
+- '96'
+- cmu
+- safari
+- victima
+uid: f165e5fac42644d9
+variations:
+  install_deps:
+    script_name: install_deps
+  plot:
+    script_name: plot
+  run:
+    script_name: run

--- a/script/reproduce-micro-2023-paper-victima/customize.py
+++ b/script/reproduce-micro-2023-paper-victima/customize.py
@@ -1,0 +1,22 @@
+from cmind import utils
+import os
+
+def preprocess(i):
+
+    os_info = i['os_info']
+
+    env = i['env']
+
+    meta = i['meta']
+
+    automation = i['automation']
+
+    quiet = (env.get('CM_QUIET', False) == 'yes')
+
+    return {'return':0}
+
+def postprocess(i):
+
+    env = i['env']
+
+    return {'return':0}

--- a/script/reproduce-micro-2023-paper-victima/install_deps.sh
+++ b/script/reproduce-micro-2023-paper-victima/install_deps.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+CUR_DIR=${PWD}
+
+echo ""
+echo "Current execution path: ${CUR_DIR}"
+echo "Path to script: ${CM_TMP_CURRENT_SCRIPT_PATH}"
+
+echo "Changing to Victima repo: ${CM_GIT_REPO_CMU_SAFARI_VICTIMA_CHECKOUT_PATH}"
+cd ${CM_GIT_REPO_CMU_SAFARI_VICTIMA_CHECKOUT_PATH}
+
+if test -f "${CM_TMP_CURRENT_SCRIPT_PATH}/requirements.txt"; then
+  echo ""
+  echo "Installing requirements.txt ..."
+  echo ""
+
+  ${CM_PYTHON_BIN_WITH_PATH} -m pip install -r ${CM_TMP_CURRENT_SCRIPT_PATH}/requirements.txt
+  test $? -eq 0 || exit 1
+fi
+
+echo ""
+
+sh install_docker.sh
+test $? -eq 0 || exit 1

--- a/script/reproduce-micro-2023-paper-victima/main.py
+++ b/script/reproduce-micro-2023-paper-victima/main.py
@@ -1,0 +1,10 @@
+import os
+
+if __name__ == "__main__":
+
+    print ('')
+    print ('Main script:')
+    print ('Experiment: {}'.format(os.environ.get('CM_EXPERIMENT','')))
+    print ('')
+
+    exit(0)

--- a/script/reproduce-micro-2023-paper-victima/plot.sh
+++ b/script/reproduce-micro-2023-paper-victima/plot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CUR_DIR=${PWD}
+
+echo ""
+echo "Current execution path: ${CUR_DIR}"
+echo "Path to script: ${CM_TMP_CURRENT_SCRIPT_PATH}"
+
+echo "Changing to Victima repo: ${CM_GIT_REPO_CMU_SAFARI_VICTIMA_CHECKOUT_PATH}"
+cd ${CM_GIT_REPO_CMU_SAFARI_VICTIMA_CHECKOUT_PATH}
+
+echo ""
+sh ./scripts/produce_plots.sh ${CM_VICTIMA_CONTAINER}
+test $? -eq 0 || exit 1

--- a/script/reproduce-micro-2023-paper-victima/run.sh
+++ b/script/reproduce-micro-2023-paper-victima/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+CUR_DIR=${PWD}
+
+echo ""
+echo "Current execution path: ${CUR_DIR}"
+echo "Path to script: ${CM_TMP_CURRENT_SCRIPT_PATH}"
+
+echo "Changing to Victima repo: ${CM_GIT_REPO_CMU_SAFARI_VICTIMA_CHECKOUT_PATH}"
+cd ${CM_GIT_REPO_CMU_SAFARI_VICTIMA_CHECKOUT_PATH}
+
+echo ""
+
+sh artifact.sh --${CM_VICTIMA_JOB_MANAGER} ${CM_VICTIMA_CONTAINER}
+test $? -eq 0 || exit 1


### PR DESCRIPTION
Hi,
I checked your artifact further this weekend and realized that there is a simpler and more preferred way to run your artifact via CM. 
In fact, you can add your repository as a dependency that will cache it in CM.
Then you can use variations to install deps, run script and plot results.
Furthermore, you do not need to do any changes in your repository - you call your native scripts directly (and you don't need soft link).
You can also map input flags in CM to the environment variables (--job_manager and --container).
Please check it out and tell me if it's ok. 
If something is not clear, I will be happy to explain you more!
Thanks again for your effort to share your artifacts!
